### PR TITLE
[PKG-2609] numpy-financial 1.0.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [py<35]
-  skip: True  # [not (linux and x86_64)]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +21,9 @@ requirements:
     - setuptools
     - wheel
   run:
-    - numpy >=1.15,<1.24
+    # test_financial.py::TestFinancial::test_fv fails on linux-64 for numpy >=1.24
+    - numpy >=1.15,<1.24  # [linux and x86_64]
+    - numpy >=1.15  # [not (linux and x86_64)]
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "numpy-financial" %}
 {% set version = "1.0.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,29 +11,31 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<35]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
+    - setuptools
+    - wheel
   run:
     - numpy >=1.15
-    - python >=3.5
+    - python
 
 test:
   imports:
     - numpy_financial
     - numpy_financial.tests
-  commands:
-    - pip check
-    - pytest numpy_financial/tests
+  source_files:
+    - numpy_financial/tests
   requires:
     - pip
     - pytest
-  source_files:
-    - numpy_financial/tests
+  commands:
+    - pip check
+    - pytest numpy_financial/tests
 
 about:
   home: https://numpy.org/numpy-financial/
@@ -44,7 +45,6 @@ about:
   license_file: LICENSE.txt
   description: |
     The `numpy-financial` package contains a collection of elementary financial functions.
-    
     The [financial functions in NumPy](https://numpy.org/doc/1.17/reference/routines.financial.html)
     are deprecated and eventually will be removed from NumPy; see
     [NEP-32](https://numpy.org/neps/nep-0032-remove-financial-functions.html) for more information.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<35]
+  skip: True  # [not (linux and x86_64)]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -21,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - numpy >=1.15
+    - numpy >=1.15,<1.25
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - numpy >=1.15,<1.25
+    - numpy >=1.15,<1.24
     - python
 
 test:


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| conda-forge | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/numpy-financial.svg)](https://anaconda.org/conda-forge/numpy-financial) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/numpy-financial.svg)](https://anaconda.org/conda-forge/numpy-financial) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/numpy-financial.svg)](https://anaconda.org/conda-forge/numpy-financial) | ![Conda License](https://img.shields.io/conda/l/conda-forge/numpy-financial) |

Changelog: https://github.com/numpy/numpy-financial/releases
License: https://github.com/numpy/numpy-financial/blob/v1.0.0/LICENSE.txt
Requirements:
- https://github.com/numpy/numpy-financial/blob/v1.0.0/requirements.txt
- https://github.com/numpy/numpy-financial/blob/v1.0.0/setup.py

Actions:
1. Clean up the `noarch python` recipe
2. Use `numpy >=1.15,<1.24`  on `linux-64` because `test_financial.py::TestFinancial::test_fv` fails. The [test_fv](https://github.com/numpy/numpy-financial/blob/v1.0.0/numpy_financial/tests/test_financial.py#L57) relies on old `python` and `numpy` versions but we apply the upper bound to be sure that the function `npf.fv()` works correctly. Anyway, it will be removed in the next release 1.1.0. 

Notes:
- `numpy-financial 1.0.0` was released in 2019.
